### PR TITLE
Fix canHarvest

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,6 +121,7 @@ function provider ({ Biome, blocks, blocksByStateId, toolMultipliers, shapes, ma
   }
 
   Block.prototype.canHarvest = function (heldItemType) {
+    if(!this.harvestTools){return true};
     return heldItemType && this.harvestTools && this.harvestTools[heldItemType]
   }
 

--- a/index.js
+++ b/index.js
@@ -121,7 +121,7 @@ function provider ({ Biome, blocks, blocksByStateId, toolMultipliers, shapes, ma
   }
 
   Block.prototype.canHarvest = function (heldItemType) {
-    if (!this.harvestTools) { return true }; //for blocks harvestable by hand
+    if (!this.harvestTools) { return true }; // for blocks harvestable by hand
     return heldItemType && this.harvestTools && this.harvestTools[heldItemType]
   }
 

--- a/index.js
+++ b/index.js
@@ -121,7 +121,7 @@ function provider ({ Biome, blocks, blocksByStateId, toolMultipliers, shapes, ma
   }
 
   Block.prototype.canHarvest = function (heldItemType) {
-    if(!this.harvestTools){return true};
+    if (!this.harvestTools) { return true }; //for blocks harvestable by hand
     return heldItemType && this.harvestTools && this.harvestTools[heldItemType]
   }
 


### PR DESCRIPTION
There was an issue with `digTime `being calculated incorrectly for blocks which have no `harvestTools `because they can be mined by hand, such as wool.
This led to the `digTime `being much longer because of the check in line 151.

The function `Block.prototype.canHarvest` will now return true for blocks that can be mined by hand and therefore have no `harvestTools `property.