### PR TITLE
Refactor digTime, bring it up to date with 1.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Tells you how long it will take to dig the block, in milliseconds.
  * `creative` game in creative
  * `inWater` the bot is in water
  * `notOnGround` the bot is not on the ground
- * `enchantments` list of enchantments from the held item (from simplified nbt data)
+ * `enchantments` list of enchantments from the held item (from simplified nbt data) **AND** equipped armor - Aqua Affinity enchantment on helmet also affects breaking speed
  * `effects` effects on the bot (bot.entity.effects)
 
 #### block.position

--- a/index.js
+++ b/index.js
@@ -220,7 +220,7 @@ function provider ({ Biome, blocks, blocksByStateId, toolMultipliers, shapes, is
 
   function getMiningFatigueMultiplier (effectLevel) {
     switch (effectLevel) {
-      case 0: return 0.0
+      case 0: return 1.0
       case 1: return 0.3
       case 2: return 0.09
       case 3: return 0.0027
@@ -263,12 +263,12 @@ function provider ({ Biome, blocks, blocksByStateId, toolMultipliers, shapes, is
     // Mining fatigue is applied afterwards, but multiplier only decreases up to level 4
     const miningFatigueLevel = getEffectLevel(statusEffectNames.miningFatigueEffectName, effects)
 
-    if (miningFatigueLevel >= 0) {
+    if (miningFatigueLevel > 0) {
       blockBreakingSpeed *= getMiningFatigueMultiplier(miningFatigueLevel)
     }
 
     // Apply 5x breaking speed de-buff if we are submerged in water and do not have aqua affinity
-    const aquaAffinityLevel = getEnchantmentLevel('aqua_affinity', effects)
+    const aquaAffinityLevel = getEnchantmentLevel('aqua_affinity', enchantments)
 
     if (inWater && aquaAffinityLevel === 0) {
       blockBreakingSpeed /= 5.0

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ function loader (mcVersion) {
     blocksByStateId: mcData.blocksByStateId,
     toolMultipliers: mcData.materials,
     shapes: mcData.blockCollisionShapes,
-    isVersionNewerOrEqualTo: mcData.isNewerOrEqualTo.bind(mcData),
+    isVersionNewerOrEqualTo: mcData.type === 'pe' ? () => false : mcData.isNewerOrEqualTo.bind(mcData),
     effectsByName: mcData.effectsByName,
     enchantmentsByName: mcData.enchantmentsByName
   })

--- a/index.js
+++ b/index.js
@@ -194,8 +194,15 @@ function provider ({ Biome, blocks, blocksByStateId, toolMultipliers, shapes, is
   }
 
   function getEffectLevel (effectName, effects) {
-    const e = effects[effectsByName[effectName].id]
-    return e ? e.amplifier : -1
+    const effectDescriptor = effectsByName[effectName]
+    if (!effectDescriptor) {
+      return 0
+    }
+    const effectInfo = effects[effectDescriptor.id]
+    if (!effectInfo) {
+      return 0
+    }
+    return effectInfo.amplifier + 1
   }
 
   function getEnchantmentLevel (enchantmentKey, enchantments) {

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ function loader (mcVersion) {
     blocksByStateId: mcData.blocksByStateId,
     toolMultipliers: mcData.materials,
     shapes: mcData.blockCollisionShapes,
-    isVersionNewerOrEqualTo: mcData.isNewerOrEqualTo,
+    isVersionNewerOrEqualTo: mcData.isNewerOrEqualTo.bind(mcData),
     effectsByName: mcData.effectsByName
   })
 }

--- a/index.js
+++ b/index.js
@@ -175,21 +175,21 @@ function provider ({ Biome, blocks, blocksByStateId, toolMultipliers, shapes, is
   // 1.17+: effect names have been fixed to actually match their registry names
   if (isVersionNewerOrEqualTo('1.17')) {
     blockDigTimeData = {
-      enchantmentKey: 'efficiency',
+      efficiencyEnchantmentKey: 'efficiency',
       hasteEffectName: 'haste',
       miningFatigueEffectName: 'mining_fatigue',
       conduitPowerEffectName: 'conduit_power',
-      aquaAffinityEnchantmentName: 'aqua_affinity'
+      aquaAffinityEnchantmentKey: 'aqua_affinity'
     }
   } else {
     // 1.13+: enchantments are no longer stored by IDs, but rather by registry names
     const isPost113 = isVersionNewerOrEqualTo('1.13')
     blockDigTimeData = {
-      enchantmentKey: isPost113 ? 'efficiency' : 32,
+      efficiencyEnchantmentKey: isPost113 ? 'efficiency' : 32,
       hasteEffectName: 'Haste',
       miningFatigueEffectName: 'MiningFatigue',
       conduitPowerEffectName: 'ConduitPower',
-      aquaAffinityEnchantmentName: 'AquaAffinity'
+      aquaAffinityEnchantmentKey: isPost113 ? 'aqua_affinity' : 6
     }
   }
 
@@ -206,12 +206,13 @@ function provider ({ Biome, blocks, blocksByStateId, toolMultipliers, shapes, is
   }
 
   function getEnchantmentLevel (enchantmentKey, enchantments) {
-    for (const e of enchantments) {
-      if (typeof enchantmentKey === 'string' ? e.id.includes(enchantmentKey) : e.id === enchantmentKey) {
-        return e.lvl
+    const isStringKey = typeof enchantmentKey === 'string'
+    for (const enchInfo of enchantments) {
+      if (isStringKey ? enchInfo.id.includes(enchantmentKey) : enchInfo.id === enchantmentKey) {
+        return enchInfo.lvl
       }
     }
-    return -1
+    return 0
   }
 
   function getMiningFatigueMultiplier (effectLevel) {
@@ -241,8 +242,8 @@ function provider ({ Biome, blocks, blocksByStateId, toolMultipliers, shapes, is
     }
 
     // Efficiency is applied if tools speed multiplier is more than 1.0
-    const efficiencyLevel = getEnchantmentLevel(blockDigTimeData.enchantmentKey, enchantments)
-    if (efficiencyLevel >= 0 && blockBreakingSpeed > 1.0) {
+    const efficiencyLevel = getEnchantmentLevel(blockDigTimeData.efficiencyEnchantmentKey, enchantments)
+    if (efficiencyLevel > 0 && blockBreakingSpeed > 1.0) {
       blockBreakingSpeed += efficiencyLevel * efficiencyLevel + 1
     }
 
@@ -264,7 +265,7 @@ function provider ({ Biome, blocks, blocksByStateId, toolMultipliers, shapes, is
     }
 
     // Apply 5x breaking speed de-buff if we are submerged in water and do not have aqua affinity
-    const aquaAffinityLevel = getEnchantmentLevel(blockDigTimeData.miningFatigueEffectName, effects)
+    const aquaAffinityLevel = getEnchantmentLevel(blockDigTimeData.aquaAffinityEnchantmentKey, effects)
 
     if (inWater && aquaAffinityLevel === 0) {
       blockBreakingSpeed /= 5.0

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "jest": "^27.0.4",
-    "minecraft-data": "file:../node-minecraft-data",
+    "minecraft-data": "^2.62.1",
     "standard": "^16.0.1",
     "vec3": "^0.1.4"
   },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "jest": "^27.0.4",
-    "minecraft-data": "^2.62.1",
+    "minecraft-data": "file:../node-minecraft-data",
     "standard": "^16.0.1",
     "vec3": "^0.1.4"
   },

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -37,5 +37,112 @@ describe('Dig time', () => {
       const time = block.digTime(null, true, false, false, [], {})
       expect(time).toBe(0)
     })
+    describe('digging', () => {
+      for (const blockName of ['sand', 'dirt', 'soul_sand']) {
+        describe(`digging ${blockName}`, () => {
+          test('using iron_shovel', () => {
+            const tool = mcData.itemsByName.iron_shovel
+            const block = Block.fromStateId(mcData.blocksByName[blockName].defaultState)
+            const time = block.digTime(tool.id, false, false, false, [], {})
+            expect(time).toBe(150)
+          })
+          test('using iron_shovel with efficiency 2', () => {
+            const tool = mcData.itemsByName.iron_shovel
+            const block = Block.fromStateId(mcData.blocksByName[blockName].defaultState)
+            const time = block.digTime(tool.id, false, false, false, [{ id: 'efficiency', lvl: 2 }], {})
+            expect(time).toBe(100)
+          })
+          test('using iron_shovel with efficiency 5 (instant break)', () => {
+            const tool = mcData.itemsByName.iron_shovel
+            const block = Block.fromStateId(mcData.blocksByName[blockName].defaultState)
+            const time = block.digTime(tool.id, false, false, false, [{ id: 'efficiency', lvl: 5 }], {})
+            expect(time).toBe(0)
+          })
+          test('using iron_shovel with haste 2', () => {
+            const tool = mcData.itemsByName.iron_shovel
+            const block = Block.fromStateId(mcData.blocksByName[blockName].defaultState)
+            const time = block.digTime(tool.id, false, false, false, [], { [mcData.effectsByName.haste.id]: { amplifier: 1, lvl: 1 } })
+            expect(time).toBe(100)
+          })
+          test('using iron_shovel with eff 2 + haste 2 (instant break)', () => {
+            const tool = mcData.itemsByName.iron_shovel
+            const block = Block.fromStateId(mcData.blocksByName[blockName].defaultState)
+            const time = block.digTime(tool.id, false, false, false, [{ id: 'efficiency', lvl: 2 }], { [mcData.effectsByName.haste.id]: { amplifier: 1, lvl: 1 } })
+            expect(time).toBe(0)
+          })
+        })
+      }
+    })
+
+    describe('mining', () => {
+      describe('mining stone', () => {
+        const blockName = 'stone'
+        const toolName = 'iron_pickaxe'
+        test('using iron_shovel', () => {
+          const tool = mcData.itemsByName[toolName]
+          const block = Block.fromStateId(mcData.blocksByName[blockName].defaultState)
+          const time = block.digTime(tool.id, false, false, false, [], {})
+          expect(time).toBe(400)
+        })
+        test('using iron_shovel with efficiency 2', () => {
+          const tool = mcData.itemsByName[toolName]
+          const block = Block.fromStateId(mcData.blocksByName[blockName].defaultState)
+          const time = block.digTime(tool.id, false, false, false, [{ id: 'efficiency', lvl: 2 }], {})
+          expect(time).toBe(250)
+        })
+        test('using iron_shovel with efficiency 5 (instant break)', () => {
+          const tool = mcData.itemsByName[toolName]
+          const block = Block.fromStateId(mcData.blocksByName[blockName].defaultState)
+          const time = block.digTime(tool.id, false, false, false, [{ id: 'efficiency', lvl: 5 }], {})
+          expect(time).toBe(100)
+        })
+        test('using iron_shovel with haste 2', () => {
+          const tool = mcData.itemsByName[toolName]
+          const block = Block.fromStateId(mcData.blocksByName[blockName].defaultState)
+          const time = block.digTime(tool.id, false, false, false, [], { [mcData.effectsByName.haste.id]: { amplifier: 1, lvl: 1 } })
+          expect(time).toBe(300)
+        })
+        test('using iron_shovel with eff 2 + haste 2 (instant break)', () => {
+          const tool = mcData.itemsByName[toolName]
+          const block = Block.fromStateId(mcData.blocksByName[blockName].defaultState)
+          const time = block.digTime(tool.id, false, false, false, [{ id: 'efficiency', lvl: 2 }], { [mcData.effectsByName.haste.id]: { amplifier: 1, lvl: 1 } })
+          expect(time).toBe(150)
+        })
+      })
+      describe('mining iron_ore', () => {
+        const blockName = 'iron_ore'
+        const toolName = 'iron_pickaxe'
+        test('using iron_shovel', () => {
+          const tool = mcData.itemsByName[toolName]
+          const block = Block.fromStateId(mcData.blocksByName[blockName].defaultState)
+          const time = block.digTime(tool.id, false, false, false, [], {})
+          expect(time).toBe(750)
+        })
+        test('using iron_shovel with efficiency 2', () => {
+          const tool = mcData.itemsByName[toolName]
+          const block = Block.fromStateId(mcData.blocksByName[blockName].defaultState)
+          const time = block.digTime(tool.id, false, false, false, [{ id: 'efficiency', lvl: 2 }], {})
+          expect(time).toBe(450)
+        })
+        test('using iron_shovel with efficiency 5 (instant break)', () => {
+          const tool = mcData.itemsByName[toolName]
+          const block = Block.fromStateId(mcData.blocksByName[blockName].defaultState)
+          const time = block.digTime(tool.id, false, false, false, [{ id: 'efficiency', lvl: 5 }], {})
+          expect(time).toBe(150)
+        })
+        test('using iron_shovel with haste 2', () => {
+          const tool = mcData.itemsByName[toolName]
+          const block = Block.fromStateId(mcData.blocksByName[blockName].defaultState)
+          const time = block.digTime(tool.id, false, false, false, [], { [mcData.effectsByName.haste.id]: { amplifier: 1, lvl: 1 } })
+          expect(time).toBe(550)
+        })
+        test('using iron_shovel with eff 2 + haste 2 (instant break)', () => {
+          const tool = mcData.itemsByName[toolName]
+          const block = Block.fromStateId(mcData.blocksByName[blockName].defaultState)
+          const time = block.digTime(tool.id, false, false, false, [{ id: 'efficiency', lvl: 2 }], { [mcData.effectsByName.haste.id]: { amplifier: 1, lvl: 1 } })
+          expect(time).toBe(300)
+        })
+      })
+    })
   })
 })

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -1,13 +1,41 @@
 /* eslint-env jest */
 
-const Block = require('../')('1.15.2')
-const mcData = require('minecraft-data')('1.15.2')
-
 // https://minecraft.gamepedia.com/Breaking#Blocks_by_hardness
 describe('Dig time', () => {
-  test('dirt by hand', () => {
-    const block = Block.fromStateId(mcData.blocksByName.dirt.defaultState, 0)
-    const time = block.digTime(null, false, false, false)
-    expect(time).toBe(750)
+  describe('1.15.2', () => {
+    const Block = require('../')('1.15.2')
+    const mcData = require('minecraft-data')('1.15.2')
+    test('dirt by hand', () => {
+      const block = Block.fromStateId(mcData.blocksByName.dirt.defaultState, 0)
+      const time = block.digTime(null, false, false, false)
+      expect(time).toBe(750)
+    })
+  })
+  describe('1.17', () => {
+    const Block = require('../')('1.17')
+    const mcData = require('minecraft-data')('1.17')
+    test('instant break stone', () => {
+      const block = Block.fromStateId(mcData.blocksByName.stone.defaultState, 0)
+      const time = block.digTime(
+        mcData.itemsByName.diamond_pickaxe.id,
+        false,
+        false,
+        false,
+        [{ id: mcData.enchantmentsByName.efficiency.name, lvl: 5 }],
+        {
+          [mcData.effectsByName.haste.id]: {
+            amplifier: 1,
+            duration: 60
+          }
+        }
+      )
+      expect(time).toBe(0)
+    })
+
+    test('instant break bedrock (creative)', () => {
+      const block = Block.fromStateId(mcData.blocksByName.bedrock.defaultState, 0)
+      const time = block.digTime(null, true, false, false, [], {})
+      expect(time).toBe(0)
+    })
   })
 })


### PR DESCRIPTION
Noticeable changes include:
* Correctly apply non-matching-tool penalty (was 0.33x before, now 0.3x)
* Do not apply in-water penalty with aqua affinity enchantment
* Limit maximum mining fatigue debuff to level 4, like in vanilla client
* Take conduit power status effect into consideration (works like hast, effect with maximum level is used)
* Armor enchantments should now also be passed into enchantment arguments
* Migrated version-specific checks to check protocol instead of checking major version like double
* Refactored code to be more version-independent