### PR TITLE
Support prismarine-registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ Represent a minecraft block with its associated data
 ## Usage
 
 ```js
-const Block = require('prismarine-block')('1.8')
+const registry = require('prismarine-registry')('1.8')
+const Block = require('prismarine-block')(registry)
 
-const stoneBlock = new Block(1, 1, 0)
+const stoneBlock = new Block(registry.blocksByName.stone, registry.biomesByName.plains, /* meta */ 0)
 
 console.log(stoneBlock)
 
@@ -131,6 +132,9 @@ The set of tools that will allow you to harvest the block.
 The blocks or items dropped by that block.
 
 ## History
+
+### 1.12.0
+* Updated to support `prismarine-registry`. To use, instead of passing a string to prismarine-biome's default function export, pass an instance of `prismarine-registry`.
 
 ### 1.11.0
 

--- a/example.js
+++ b/example.js
@@ -1,6 +1,7 @@
-const Block = require('./')('1.8')
+const registry = require('prismarine-registry')('1.8')
+const Block = require('prismarine-block')(registry)
 
-const stoneBlock = new Block(1, 1, 0)
+const stoneBlock = new Block(registry.blocksByName.stone, registry.biomesByName.plains, /* meta */ 0)
 
 console.log(stoneBlock)
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
 import { Vec3 } from 'vec3';
 import { Biome } from 'prismarine-biome';
 import { NormalizedEnchant } from 'prismarine-item';
+import Registry from 'prismarine-registry';
 
 interface Effect {
     id: number;
@@ -151,4 +152,6 @@ declare class Block {
     static fromProperties(typeId: number, properties: { [key: string]: string | number }, biomeId: number): Block;
 }
 
+/** @deprecated */
 export declare function loader(mcVersion: string): typeof Block;
+export declare function loader(registry: ReturnType<typeof Registry>): typeof Block;

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ module.exports.testedVersions = ['1.8.8', '1.9.4', '1.10.2', '1.11.2', '1.12.2',
 
 function loader (registryOrVersion) {
   const registry = typeof registryOrVersion === 'string' ? require('prismarine-registry')(registryOrVersion) : registryOrVersion
-  const mcVersion = registry.version.type === 'bedrock' ? 'bedrock_' + registry.version.majorVersion : registry.version.minecraftVersion // Legacy
+  const mcVersion = registry.version.type === 'bedrock' ? 'bedrock_' + registry.version.majorVersion : registry.version.minecraftVersion // until prismarine-biome supports registry
 
   const version = registry.version
   const features = {
@@ -14,7 +14,6 @@ function loader (registryOrVersion) {
   return provider(registry, { Biome: require('prismarine-biome')(mcVersion), features, version })
 }
 
-// { Biome, blocks, blocksByName, blocksByStateId, blockStates, toolMultipliers, shapes, version, effectsByName, enchantmentsByName }
 function provider (registry, { Biome, version, features }) {
   Block.fromStateId = function (stateId, biomeId) {
     // 1.13+: metadata is completely removed and only block state IDs are used

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ function provider (registry, { Biome, version, features }) {
       if (value === false) return 1
     }
     // Assume by-name mapping for unknown properties
-    return state.values.indexOf(value.toString())
+    return state.values?.indexOf(value.toString()) ?? 0
   }
 
   function getStateValue (states, name, value) {

--- a/index.js
+++ b/index.js
@@ -1,26 +1,24 @@
 module.exports = loader
 module.exports.testedVersions = ['1.8.8', '1.9.4', '1.10.2', '1.11.2', '1.12.2', '1.13.2', '1.14.4', '1.15.2', '1.16.4', 'bedrock_1.17.10', 'bedrock_1.18.0']
 
-function loader (mcVersion) {
-  const mcData = require('minecraft-data')(mcVersion)
-  return provider({
-    Biome: require('prismarine-biome')(mcVersion),
-    blocks: mcData.blocks,
-    blockStates: mcData.blockStates,
-    blocksByName: mcData.blocksByName,
-    blocksByStateId: mcData.blocksByStateId,
-    toolMultipliers: mcData.materials,
-    shapes: mcData.blockCollisionShapes,
-    version: mcData.version,
-    effectsByName: mcData.effectsByName,
-    enchantmentsByName: mcData.enchantmentsByName
-  })
+function loader (registryOrVersion) {
+  const registry = typeof registryOrVersion === 'string' ? require('prismarine-registry')(registryOrVersion) : registryOrVersion
+  const mcVersion = registry.version.type === 'bedrock' ? 'bedrock_' + registry.version.majorVersion : registry.version.minecraftVersion // Legacy
+
+  const version = registry.version
+  const features = {
+    usesBlockStates: (version.type === 'pc' && version['>=']('1.13')) || (version.type === 'bedrock'),
+    effectNamesMatchRegistryName: version['>=']('1.17')
+  }
+
+  return provider(registry, { Biome: require('prismarine-biome')(mcVersion), features, version })
 }
 
-function provider ({ Biome, blocks, blocksByName, blocksByStateId, blockStates, toolMultipliers, shapes, version, effectsByName, enchantmentsByName }) {
+// { Biome, blocks, blocksByName, blocksByStateId, blockStates, toolMultipliers, shapes, version, effectsByName, enchantmentsByName }
+function provider (registry, { Biome, version, features }) {
   Block.fromStateId = function (stateId, biomeId) {
     // 1.13+: metadata is completely removed and only block state IDs are used
-    if ((version.type === 'pc' && version['>=']('1.13')) || (version.type === 'bedrock')) {
+    if (features.usesBlockStates) {
       return new Block(undefined, biomeId, 0, stateId)
     } else {
       return new Block(stateId >> 4, biomeId, stateId & 15)
@@ -52,7 +50,7 @@ function provider ({ Biome, blocks, blocksByName, blocksByStateId, blockStates, 
   }
 
   Block.fromProperties = function (typeId, properties, biomeId) {
-    const block = typeof typeId === 'string' ? blocksByName[typeId] : blocks[typeId]
+    const block = typeof typeId === 'string' ? registry.blocksByName[typeId] : registry.blocks[typeId]
 
     if (block.minStateId == null) {
       throw new Error('Block properties not available in current Minecraft version!')
@@ -66,7 +64,7 @@ function provider ({ Biome, blocks, blocksByName, blocksByStateId, blockStates, 
       return new Block(undefined, biomeId, 0, block.minStateId + data)
     } else if (version.type === 'bedrock') {
       for (let stateId = block.minStateId; stateId <= block.maxStateId; stateId++) {
-        const state = blockStates[stateId].states
+        const state = registry.blockStates[stateId].states
         if (Object.entries(properties).find(([prop, val]) => state[prop]?.value !== val)) continue
         return new Block(undefined, biomeId, 0, stateId)
       }
@@ -74,10 +72,11 @@ function provider ({ Biome, blocks, blocksByName, blocksByStateId, blockStates, 
     }
   }
 
+  const shapes = registry.blockCollisionShapes
   if (shapes) {
     // Prepare block shapes
-    for (const id in blocks) {
-      const block = blocks[id]
+    for (const id in registry.blocks) {
+      const block = registry.blocks[id]
       const shapesId = shapes.blocks[block.name]
       block.shapes = (shapesId instanceof Array) ? shapes.shapes[shapesId[0]] : shapes.shapes[shapesId]
       if (block.states || version.type === 'bedrock') { // post 1.13
@@ -117,7 +116,7 @@ function provider ({ Biome, blocks, blocksByName, blocksByStateId, blockStates, 
     this.position = null
     this.stateId = stateId
 
-    const blockEnum = stateId === undefined ? blocks[type] : blocksByStateId[stateId]
+    const blockEnum = stateId === undefined ? registry.blocks[type] : registry.blocksByStateId[stateId]
     if (blockEnum) {
       if (stateId === undefined) {
         this.stateId = blockEnum.minStateId
@@ -171,7 +170,7 @@ function provider ({ Biome, blocks, blocksByName, blocksByStateId, blockStates, 
 
   function getPropertiesPC () {
     const properties = {}
-    const blockEnum = this.stateId === undefined ? blocks[this.type] : blocksByStateId[this.stateId]
+    const blockEnum = this.stateId === undefined ? registry.blocks[this.type] : registry.blocksByStateId[this.stateId]
     if (blockEnum && blockEnum.states) {
       let data = this.metadata
       for (let i = blockEnum.states.length - 1; i >= 0; i--) {
@@ -184,7 +183,7 @@ function provider ({ Biome, blocks, blocksByName, blocksByStateId, blockStates, 
   }
 
   function getPropertiesBedrock () {
-    const states = blockStates[this.stateId].states
+    const states = registry.blockStates[this.stateId].states
     const ret = {}
     for (const state in states) {
       ret[state] = states[state].value
@@ -203,7 +202,7 @@ function provider ({ Biome, blocks, blocksByName, blocksByStateId, blockStates, 
   let statusEffectNames
 
   // 1.17+: effect names have been fixed to actually match their registry names
-  if (version['>=']('1.17')) {
+  if (features.effectNamesMatchRegistryName) {
     statusEffectNames = {
       hasteEffectName: 'haste',
       miningFatigueEffectName: 'mining_fatigue',
@@ -218,7 +217,7 @@ function provider ({ Biome, blocks, blocksByName, blocksByStateId, blockStates, 
   }
 
   function getEffectLevel (effectName, effects) {
-    const effectDescriptor = effectsByName[effectName]
+    const effectDescriptor = registry.effectsByName[effectName]
     if (!effectDescriptor) {
       return 0
     }
@@ -230,7 +229,7 @@ function provider ({ Biome, blocks, blocksByName, blocksByStateId, blockStates, 
   }
 
   function getEnchantmentLevel (enchantmentName, enchantments) {
-    const enchantmentDescriptor = enchantmentsByName[enchantmentName]
+    const enchantmentDescriptor = registry.enchantmentsByName[enchantmentName]
     if (!enchantmentDescriptor) {
       return 0
     }
@@ -263,7 +262,7 @@ function provider ({ Biome, blocks, blocksByName, blocksByStateId, blockStates, 
   Block.prototype.digTime = function (heldItemType, creative, inWater, notOnGround, enchantments = [], effects = {}) {
     if (creative) return 0
 
-    const materialToolMultipliers = toolMultipliers[this.material]
+    const materialToolMultipliers = registry.materials[this.material]
     const isBestTool = heldItemType && materialToolMultipliers && materialToolMultipliers[heldItemType]
 
     // Compute breaking speed multiplier

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "minecraft-data": "^2.62.1",
     "mocha": "^9.1.3",
     "standard": "^16.0.4",
-    "vec3": "^0.1.4"
+    "vec3": "^0.1.4",
+    "prismarine-block": "file:."
   },
   "keywords": [
     "prismarine",

--- a/package.json
+++ b/package.json
@@ -15,15 +15,16 @@
   },
   "dependencies": {
     "prismarine-biome": "^1.1.0",
-    "prismarine-item": "^1.10.1"
+    "prismarine-item": "^1.10.1",
+    "prismarine-registry": "^1.1.0"
   },
   "peerDependencies": {
     "minecraft-data": "^2.62.1"
   },
   "devDependencies": {
-    "mocha": "^9.1.3",
     "expect": "^27.3.1",
     "minecraft-data": "^2.62.1",
+    "mocha": "^9.1.3",
     "standard": "^16.0.4",
     "vec3": "^0.1.4"
   },

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -5,21 +5,21 @@ const expect = require('expect')
 // https://minecraft.gamepedia.com/Breaking#Blocks_by_hardness
 describe('Dig time', () => {
   describe('1.15.2', () => {
-    const Block = require('../')('1.15.2')
-    const mcData = require('minecraft-data')('1.15.2')
+    const registry = require('prismarine-registry')('1.15.2')
+    const Block = require('prismarine-block')(registry)
     it('dirt by hand', () => {
-      const block = Block.fromStateId(mcData.blocksByName.dirt.defaultState, 0)
+      const block = Block.fromStateId(registry.blocksByName.dirt.defaultState, 0)
       const time = block.digTime(null, false, false, false)
       expect(time).toBe(750)
     })
   })
 
   describe('bedrock 1.17.10', () => {
-    const Block = require('../')('bedrock_1.17.10')
-    const mcData = require('minecraft-data')('bedrock_1.17.10')
+    const registry = require('prismarine-registry')('bedrock_1.17.10')
+    const Block = require('prismarine-block')(registry)
 
     it('dirt by hand', () => {
-      const block = Block.fromStateId(mcData.blocksByName.dirt.defaultState, 0)
+      const block = Block.fromStateId(registry.blocksByName.dirt.defaultState, 0)
       const time = block.digTime(null, false, false, false)
       require('assert').ok(time)
     })
@@ -27,18 +27,18 @@ describe('Dig time', () => {
 
   for (const version of ['1.17', 'bedrock_1.17.10', 'bedrock_1.18.0']) {
     describe(version, () => {
-      const Block = require('../')(version)
-      const mcData = require('minecraft-data')(version)
+      const registry = require('prismarine-registry')(version)
+      const Block = require('prismarine-block')(registry)
       it('instant break stone', () => {
-        const block = Block.fromStateId(mcData.blocksByName.stone.defaultState, 0)
+        const block = Block.fromStateId(registry.blocksByName.stone.defaultState, 0)
         const time = block.digTime(
-          mcData.itemsByName.diamond_pickaxe.id,
+          registry.itemsByName.diamond_pickaxe.id,
           false,
           false,
           false,
-          [{ name: mcData.enchantmentsByName.efficiency.name, lvl: 5 }],
+          [{ name: registry.enchantmentsByName.efficiency.name, lvl: 5 }],
           {
-            [mcData.effectsByName.haste.id]: {
+            [registry.effectsByName.haste.id]: {
               amplifier: 1,
               duration: 60
             }
@@ -48,7 +48,7 @@ describe('Dig time', () => {
       })
 
       it('instant break bedrock (creative)', () => {
-        const block = Block.fromStateId(mcData.blocksByName.bedrock.defaultState, 0)
+        const block = Block.fromStateId(registry.blocksByName.bedrock.defaultState, 0)
         const time = block.digTime(null, true, false, false, [], {})
         expect(time).toBe(0)
       })
@@ -56,33 +56,33 @@ describe('Dig time', () => {
         for (const blockName of ['sand', 'dirt', 'soul_sand']) {
           describe(`digging ${blockName}`, () => {
             it('using iron_shovel', () => {
-              const tool = mcData.itemsByName.iron_shovel
-              const block = Block.fromStateId(mcData.blocksByName[blockName].defaultState)
+              const tool = registry.itemsByName.iron_shovel
+              const block = Block.fromStateId(registry.blocksByName[blockName].defaultState)
               const time = block.digTime(tool.id, false, false, false, [], {})
               expect(time).toBe(150)
             })
             it('using iron_shovel with efficiency 2', () => {
-              const tool = mcData.itemsByName.iron_shovel
-              const block = Block.fromStateId(mcData.blocksByName[blockName].defaultState)
+              const tool = registry.itemsByName.iron_shovel
+              const block = Block.fromStateId(registry.blocksByName[blockName].defaultState)
               const time = block.digTime(tool.id, false, false, false, [{ name: 'efficiency', lvl: 2 }], {})
               expect(time).toBe(100)
             })
             it('using iron_shovel with efficiency 5 (instant break)', () => {
-              const tool = mcData.itemsByName.iron_shovel
-              const block = Block.fromStateId(mcData.blocksByName[blockName].defaultState)
+              const tool = registry.itemsByName.iron_shovel
+              const block = Block.fromStateId(registry.blocksByName[blockName].defaultState)
               const time = block.digTime(tool.id, false, false, false, [{ name: 'efficiency', lvl: 5 }], {})
               expect(time).toBe(0)
             })
             it('using iron_shovel with haste 2', () => {
-              const tool = mcData.itemsByName.iron_shovel
-              const block = Block.fromStateId(mcData.blocksByName[blockName].defaultState)
-              const time = block.digTime(tool.id, false, false, false, [], { [mcData.effectsByName.haste.id]: { amplifier: 1, lvl: 1 } })
+              const tool = registry.itemsByName.iron_shovel
+              const block = Block.fromStateId(registry.blocksByName[blockName].defaultState)
+              const time = block.digTime(tool.id, false, false, false, [], { [registry.effectsByName.haste.id]: { amplifier: 1, lvl: 1 } })
               expect(time).toBe(100)
             })
             it('using iron_shovel with eff 2 + haste 2 (instant break)', () => {
-              const tool = mcData.itemsByName.iron_shovel
-              const block = Block.fromStateId(mcData.blocksByName[blockName].defaultState)
-              const time = block.digTime(tool.id, false, false, false, [{ name: 'efficiency', lvl: 2 }], { [mcData.effectsByName.haste.id]: { amplifier: 1, lvl: 1 } })
+              const tool = registry.itemsByName.iron_shovel
+              const block = Block.fromStateId(registry.blocksByName[blockName].defaultState)
+              const time = block.digTime(tool.id, false, false, false, [{ name: 'efficiency', lvl: 2 }], { [registry.effectsByName.haste.id]: { amplifier: 1, lvl: 1 } })
               expect(time).toBe(0)
             })
           })
@@ -94,33 +94,33 @@ describe('Dig time', () => {
           const blockName = 'stone'
           const toolName = 'iron_pickaxe'
           it('using iron_shovel', () => {
-            const tool = mcData.itemsByName[toolName]
-            const block = Block.fromStateId(mcData.blocksByName[blockName].defaultState)
+            const tool = registry.itemsByName[toolName]
+            const block = Block.fromStateId(registry.blocksByName[blockName].defaultState)
             const time = block.digTime(tool.id, false, false, false, [], {})
             expect(time).toBe(400)
           })
           it('using iron_shovel with efficiency 2', () => {
-            const tool = mcData.itemsByName[toolName]
-            const block = Block.fromStateId(mcData.blocksByName[blockName].defaultState)
+            const tool = registry.itemsByName[toolName]
+            const block = Block.fromStateId(registry.blocksByName[blockName].defaultState)
             const time = block.digTime(tool.id, false, false, false, [{ name: 'efficiency', lvl: 2 }], {})
             expect(time).toBe(250)
           })
           it('using iron_shovel with efficiency 5 (instant break)', () => {
-            const tool = mcData.itemsByName[toolName]
-            const block = Block.fromStateId(mcData.blocksByName[blockName].defaultState)
+            const tool = registry.itemsByName[toolName]
+            const block = Block.fromStateId(registry.blocksByName[blockName].defaultState)
             const time = block.digTime(tool.id, false, false, false, [{ name: 'efficiency', lvl: 5 }], {})
             expect(time).toBe(100)
           })
           it('using iron_shovel with haste 2', () => {
-            const tool = mcData.itemsByName[toolName]
-            const block = Block.fromStateId(mcData.blocksByName[blockName].defaultState)
-            const time = block.digTime(tool.id, false, false, false, [], { [mcData.effectsByName.haste.id]: { amplifier: 1, lvl: 1 } })
+            const tool = registry.itemsByName[toolName]
+            const block = Block.fromStateId(registry.blocksByName[blockName].defaultState)
+            const time = block.digTime(tool.id, false, false, false, [], { [registry.effectsByName.haste.id]: { amplifier: 1, lvl: 1 } })
             expect(time).toBe(300)
           })
           it('using iron_shovel with eff 2 + haste 2 (instant break)', () => {
-            const tool = mcData.itemsByName[toolName]
-            const block = Block.fromStateId(mcData.blocksByName[blockName].defaultState)
-            const time = block.digTime(tool.id, false, false, false, [{ name: 'efficiency', lvl: 2 }], { [mcData.effectsByName.haste.id]: { amplifier: 1, lvl: 1 } })
+            const tool = registry.itemsByName[toolName]
+            const block = Block.fromStateId(registry.blocksByName[blockName].defaultState)
+            const time = block.digTime(tool.id, false, false, false, [{ name: 'efficiency', lvl: 2 }], { [registry.effectsByName.haste.id]: { amplifier: 1, lvl: 1 } })
             expect(time).toBe(150)
           })
         })
@@ -128,34 +128,34 @@ describe('Dig time', () => {
           const blockName = 'iron_ore'
           const toolName = 'iron_pickaxe'
           it('using iron_shovel', () => {
-            const tool = mcData.itemsByName[toolName]
-            const block = Block.fromStateId(mcData.blocksByName[blockName].defaultState)
+            const tool = registry.itemsByName[toolName]
+            const block = Block.fromStateId(registry.blocksByName[blockName].defaultState)
             console.log('Block', block)
             const time = block.digTime(tool.id, false, false, false, [], {})
             expect(time).toBe(750)
           })
           it('using iron_shovel with efficiency 2', () => {
-            const tool = mcData.itemsByName[toolName]
-            const block = Block.fromStateId(mcData.blocksByName[blockName].defaultState)
+            const tool = registry.itemsByName[toolName]
+            const block = Block.fromStateId(registry.blocksByName[blockName].defaultState)
             const time = block.digTime(tool.id, false, false, false, [{ name: 'efficiency', lvl: 2 }], {})
             expect(time).toBe(450)
           })
           it('using iron_shovel with efficiency 5 (instant break)', () => {
-            const tool = mcData.itemsByName[toolName]
-            const block = Block.fromStateId(mcData.blocksByName[blockName].defaultState)
+            const tool = registry.itemsByName[toolName]
+            const block = Block.fromStateId(registry.blocksByName[blockName].defaultState)
             const time = block.digTime(tool.id, false, false, false, [{ name: 'efficiency', lvl: 5 }], {})
             expect(time).toBe(150)
           })
           it('using iron_shovel with haste 2', () => {
-            const tool = mcData.itemsByName[toolName]
-            const block = Block.fromStateId(mcData.blocksByName[blockName].defaultState)
-            const time = block.digTime(tool.id, false, false, false, [], { [mcData.effectsByName.haste.id]: { amplifier: 1, lvl: 1 } })
+            const tool = registry.itemsByName[toolName]
+            const block = Block.fromStateId(registry.blocksByName[blockName].defaultState)
+            const time = block.digTime(tool.id, false, false, false, [], { [registry.effectsByName.haste.id]: { amplifier: 1, lvl: 1 } })
             expect(time).toBe(550)
           })
           it('using iron_shovel with eff 2 + haste 2 (instant break)', () => {
-            const tool = mcData.itemsByName[toolName]
-            const block = Block.fromStateId(mcData.blocksByName[blockName].defaultState)
-            const time = block.digTime(tool.id, false, false, false, [{ name: 'efficiency', lvl: 2 }], { [mcData.effectsByName.haste.id]: { amplifier: 1, lvl: 1 } })
+            const tool = registry.itemsByName[toolName]
+            const block = Block.fromStateId(registry.blocksByName[blockName].defaultState)
+            const time = block.digTime(tool.id, false, false, false, [{ name: 'efficiency', lvl: 2 }], { [registry.effectsByName.haste.id]: { amplifier: 1, lvl: 1 } })
             expect(time).toBe(300)
           })
         })

--- a/test/fromProperties.test.js
+++ b/test/fromProperties.test.js
@@ -3,9 +3,9 @@ const expect = require('expect')
 
 describe('Block From Properties', () => {
   it('spruce half slab: waterlogged, upper (pc_1.16.4)', () => {
-    const Block = require('../')('1.16.4')
-    const mcData = require('minecraft-data')('1.16.4')
-    const spruceSlabId = mcData.blocksByName.spruce_slab.id
+    const registry = require('prismarine-registry')('1.16.4')
+    const Block = require('prismarine-block')(registry)
+    const spruceSlabId = registry.blocksByName.spruce_slab.id
     const properties = { type: 'top', waterlogged: true }
     const block = Block.fromProperties(spruceSlabId, properties, 0)
 
@@ -13,9 +13,9 @@ describe('Block From Properties', () => {
     expect(block.getProperties()).toMatchObject(properties)
   })
   it('spruce half slab: waterlogged, upper (bedrock_1.17.10)', () => {
-    const Block = require('../')('bedrock_1.17.10')
-    const mcData = require('minecraft-data')('bedrock_1.17.10')
-    const cauldronId = mcData.blocksByName.cauldron.id
+    const registry = require('prismarine-registry')('bedrock_1.17.10')
+    const Block = require('prismarine-block')(registry)
+    const cauldronId = registry.blocksByName.cauldron.id
     const properties = { cauldron_liquid: 'water', fill_level: 5 }
     const block = Block.fromProperties(cauldronId, properties, 0)
     expect(block.getProperties()).toMatchObject(properties)

--- a/test/shape.test.js
+++ b/test/shape.test.js
@@ -5,8 +5,9 @@ const assert = require('assert')
 
 testedVersions.forEach(version => {
   describe(version, () => {
-    const blockArray = require('minecraft-data')(version).blocksArray
-    const Block = require('../')(version)
+    const registry = require('prismarine-registry')(version)
+    const blockArray = registry.blocksArray
+    const Block = require('prismarine-block')(registry)
     blockArray.forEach(block => {
       it('shape ' + block.name, () => {
         const blockV = new Block(block.id, 0, 0, block.defaultState)


### PR DESCRIPTION
Some of the previous variable aliasing in a static context was removed because prismarine-registry doesn't guarantee that the items inside the registry object won't be replaced later on