### PR TITLE
Add .blockEntity property

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ Numerical id.
 
 Array of bounding boxes representing the block shape. Each bounding box is an array of the form `[xmin, ymin, zmin, xmax, ymax, zmax]`. Depends on the type and state of the block.
 
+#### block.entity
+
+If this block is a block entity, this contains the NBT data for the entity
+
+#### block.blockEntity
+
+Simplified block entity data using prismarine-nbt's simplify() function. Only for reading - data modified here cannot be saved back later.
+
 #### block.metadata
 
 Number which represents different things depending on the block.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,6 @@
 import { Vec3 } from 'vec3';
 import { Biome } from 'prismarine-biome';
+import { NBT } from 'prismarine-nbt';
 import { NormalizedEnchant } from 'prismarine-item';
 import Registry from 'prismarine-registry';
 
@@ -30,6 +31,12 @@ declare class Block {
     light: number;
 
     skyLight: number;
+
+    // Contains a simplified NBT object
+    blockEntity: object;
+    // Only set if this block is an actual entity (or has an entity component to it)
+    // Contains a full NBT, unserialized object
+    entity: NBT | null;
 
     /**
      * A biome instance.

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 module.exports = loader
 module.exports.testedVersions = ['1.8.8', '1.9.4', '1.10.2', '1.11.2', '1.12.2', '1.13.2', '1.14.4', '1.15.2', '1.16.4', 'bedrock_1.17.10', 'bedrock_1.18.0']
 
+const nbt = require('prismarine-nbt')
+
 function loader (registryOrVersion) {
   const registry = typeof registryOrVersion === 'string' ? require('prismarine-registry')(registryOrVersion) : registryOrVersion
   const mcVersion = registry.version.type === 'bedrock' ? 'bedrock_' + registry.version.majorVersion : registry.version.minecraftVersion // until prismarine-biome supports registry
@@ -15,62 +17,6 @@ function loader (registryOrVersion) {
 }
 
 function provider (registry, { Biome, version, features }) {
-  Block.fromStateId = function (stateId, biomeId) {
-    // 1.13+: metadata is completely removed and only block state IDs are used
-    if (features.usesBlockStates) {
-      return new Block(undefined, biomeId, 0, stateId)
-    } else {
-      return new Block(stateId >> 4, biomeId, stateId & 15)
-    }
-  }
-
-  function parseValue (value, state) {
-    if (state.type === 'enum') {
-      return state.values.indexOf(value)
-    }
-    if (state.type === 'bool') {
-      if (value === true) return 0
-      if (value === false) return 1
-    }
-    // Assume by-name mapping for unknown properties
-    return state.values?.indexOf(value.toString()) ?? 0
-  }
-
-  function getStateValue (states, name, value) {
-    let offset = 1
-    for (let i = states.length - 1; i >= 0; i--) {
-      const state = states[i]
-      if (state.name === name) {
-        return offset * parseValue(value, state)
-      }
-      offset *= state.num_values
-    }
-    return 0
-  }
-
-  Block.fromProperties = function (typeId, properties, biomeId) {
-    const block = typeof typeId === 'string' ? registry.blocksByName[typeId] : registry.blocks[typeId]
-
-    if (block.minStateId == null) {
-      throw new Error('Block properties not available in current Minecraft version!')
-    }
-
-    if (version.type === 'pc') {
-      let data = 0
-      for (const [key, value] of Object.entries(properties)) {
-        data += getStateValue(block.states, key, value)
-      }
-      return new Block(undefined, biomeId, 0, block.minStateId + data)
-    } else if (version.type === 'bedrock') {
-      for (let stateId = block.minStateId; stateId <= block.maxStateId; stateId++) {
-        const state = registry.blockStates[stateId].states
-        if (Object.entries(properties).find(([prop, val]) => state[prop]?.value !== val)) continue
-        return new Block(undefined, biomeId, 0, stateId)
-      }
-      return block
-    }
-  }
-
   const shapes = registry.blockCollisionShapes
   if (shapes) {
     // Prepare block shapes
@@ -104,97 +50,6 @@ function provider (registry, { Biome, version, features }) {
         block.stateShapes = block.shapes
       }
     }
-  }
-
-  function Block (type, biomeId, metadata, stateId) {
-    this.type = type
-    this.metadata = metadata
-    this.light = 0
-    this.skyLight = 0
-    this.biome = new Biome(biomeId)
-    this.position = null
-    this.stateId = stateId
-
-    const blockEnum = stateId === undefined ? registry.blocks[type] : registry.blocksByStateId[stateId]
-    if (blockEnum) {
-      if (stateId === undefined) {
-        this.stateId = blockEnum.minStateId
-      } else {
-        this.metadata = this.stateId - blockEnum.minStateId
-      }
-      this.type = blockEnum.id
-      this.name = blockEnum.name
-      this.hardness = blockEnum.hardness
-      this.displayName = blockEnum.displayName
-      this.shapes = blockEnum.shapes
-      if (blockEnum.stateShapes) {
-        if (blockEnum.stateShapes[this.metadata] !== undefined) {
-          this.shapes = blockEnum.stateShapes[this.metadata]
-        } else {
-          // Default to shape 0
-          this.shapes = blockEnum.stateShapes[0]
-          this.missingStateShape = true
-        }
-      } else if (blockEnum.variations) {
-        const variations = blockEnum.variations
-        for (const i in variations) {
-          if (variations[i].metadata === metadata) {
-            this.displayName = variations[i].displayName
-            this.shapes = variations[i].shapes
-          }
-        }
-      }
-      this.boundingBox = blockEnum.boundingBox
-      this.transparent = blockEnum.transparent
-      this.diggable = blockEnum.diggable
-      this.material = blockEnum.material
-      this.harvestTools = blockEnum.harvestTools
-      this.drops = blockEnum.drops
-    } else {
-      this.name = ''
-      this.displayName = ''
-      this.shapes = []
-      this.hardness = 0
-      this.boundingBox = 'empty'
-      this.transparent = true
-      this.diggable = false
-    }
-  }
-
-  function propValue (state, value) {
-    if (state.type === 'enum') return state.values[value]
-    if (state.type === 'bool') return !value
-    return value
-  }
-
-  function getPropertiesPC () {
-    const properties = {}
-    const blockEnum = this.stateId === undefined ? registry.blocks[this.type] : registry.blocksByStateId[this.stateId]
-    if (blockEnum && blockEnum.states) {
-      let data = this.metadata
-      for (let i = blockEnum.states.length - 1; i >= 0; i--) {
-        const prop = blockEnum.states[i]
-        properties[prop.name] = propValue(prop, data % prop.num_values)
-        data = Math.floor(data / prop.num_values)
-      }
-    }
-    return properties
-  }
-
-  function getPropertiesBedrock () {
-    const states = registry.blockStates[this.stateId].states
-    const ret = {}
-    for (const state in states) {
-      ret[state] = states[state].value
-    }
-    return ret
-  }
-
-  Block.prototype.getProperties = { pc: getPropertiesPC, bedrock: getPropertiesBedrock }[version.type]
-
-  Block.prototype.canHarvest = function (heldItemType) {
-    if (!this.harvestTools) { return true }; // for blocks harvestable by hand
-    return heldItemType && this.harvestTools && this.harvestTools[heldItemType]
   }
 
   // Determine data required to actually compute dig times that is version-dependent
@@ -255,84 +110,241 @@ function provider (registry, { Biome, version, features }) {
     }
   }
 
-  // http://minecraft.gamepedia.com/Breaking#Calculation
-  // for more concrete information, look up following Minecraft methods (assuming yarn mappings):
-  // AbstractBlock#calcBlockBreakingDelta, PlayerEntity#getBlockBreakingSpeed, PlayerEntity#canHarvest
-  Block.prototype.digTime = function (heldItemType, creative, inWater, notOnGround, enchantments = [], effects = {}) {
-    if (creative) return 0
+  return class Block {
+    constructor (type, biomeId, metadata, stateId) {
+      this.type = type
+      this.metadata = metadata
+      this.light = 0
+      this.skyLight = 0
+      this.biome = new Biome(biomeId)
+      this.position = null
+      this.stateId = stateId
 
-    const materialToolMultipliers = registry.materials[this.material]
-    const isBestTool = heldItemType && materialToolMultipliers && materialToolMultipliers[heldItemType]
-
-    // Compute breaking speed multiplier
-    let blockBreakingSpeed = 1
-
-    if (isBestTool) {
-      blockBreakingSpeed = materialToolMultipliers[heldItemType]
+      const blockEnum = stateId === undefined ? registry.blocks[type] : registry.blocksByStateId[stateId]
+      if (blockEnum) {
+        if (stateId === undefined) {
+          this.stateId = blockEnum.minStateId
+        } else {
+          this.metadata = this.stateId - blockEnum.minStateId
+        }
+        this.type = blockEnum.id
+        this.name = blockEnum.name
+        this.hardness = blockEnum.hardness
+        this.displayName = blockEnum.displayName
+        this.shapes = blockEnum.shapes
+        if (blockEnum.stateShapes) {
+          if (blockEnum.stateShapes[this.metadata] !== undefined) {
+            this.shapes = blockEnum.stateShapes[this.metadata]
+          } else {
+            // Default to shape 0
+            this.shapes = blockEnum.stateShapes[0]
+            this.missingStateShape = true
+          }
+        } else if (blockEnum.variations) {
+          const variations = blockEnum.variations
+          for (const i in variations) {
+            if (variations[i].metadata === metadata) {
+              this.displayName = variations[i].displayName
+              this.shapes = variations[i].shapes
+            }
+          }
+        }
+        this.boundingBox = blockEnum.boundingBox
+        this.transparent = blockEnum.transparent
+        this.diggable = blockEnum.diggable
+        this.material = blockEnum.material
+        this.harvestTools = blockEnum.harvestTools
+        this.drops = blockEnum.drops
+      } else {
+        this.name = ''
+        this.displayName = ''
+        this.shapes = []
+        this.hardness = 0
+        this.boundingBox = 'empty'
+        this.transparent = true
+        this.diggable = false
+      }
     }
 
-    // Efficiency is applied if tools speed multiplier is more than 1.0
-    const efficiencyLevel = getEnchantmentLevel('efficiency', enchantments)
-    if (efficiencyLevel > 0 && blockBreakingSpeed > 1.0) {
-      blockBreakingSpeed += efficiencyLevel * efficiencyLevel + 1
+    static fromStateId (stateId, biomeId) {
+      // 1.13+: metadata is completely removed and only block state IDs are used
+      if (features.usesBlockStates) {
+        return new Block(undefined, biomeId, 0, stateId)
+      } else {
+        return new Block(stateId >> 4, biomeId, stateId & 15)
+      }
     }
 
-    // Haste is always considered when effect is present, and when both
-    // Conduit Power and Haste are present, highest level is considered
-    const hasteLevel = Math.max(
-      getEffectLevel(statusEffectNames.hasteEffectName, effects),
-      getEffectLevel(statusEffectNames.conduitPowerEffectName, effects))
+    static fromProperties (typeId, properties, biomeId) {
+      const block = typeof typeId === 'string' ? registry.blocksByName[typeId] : registry.blocks[typeId]
 
-    if (hasteLevel > 0) {
-      blockBreakingSpeed *= 1 + (0.2 * hasteLevel)
+      if (block.minStateId == null) {
+        throw new Error('Block properties not available in current Minecraft version!')
+      }
+
+      if (version.type === 'pc') {
+        let data = 0
+        for (const [key, value] of Object.entries(properties)) {
+          data += getStateValue(block.states, key, value)
+        }
+        return new Block(undefined, biomeId, 0, block.minStateId + data)
+      } else if (version.type === 'bedrock') {
+        for (let stateId = block.minStateId; stateId <= block.maxStateId; stateId++) {
+          const state = registry.blockStates[stateId].states
+          if (Object.entries(properties).find(([prop, val]) => state[prop]?.value !== val)) continue
+          return new Block(undefined, biomeId, 0, stateId)
+        }
+        return block
+      }
     }
 
-    // Mining fatigue is applied afterwards, but multiplier only decreases up to level 4
-    const miningFatigueLevel = getEffectLevel(statusEffectNames.miningFatigueEffectName, effects)
-
-    if (miningFatigueLevel > 0) {
-      blockBreakingSpeed *= getMiningFatigueMultiplier(miningFatigueLevel)
+    get blockEntity () {
+      return this.entity ? nbt.simplify(this.entity) : undefined
     }
 
-    // Apply 5x breaking speed de-buff if we are submerged in water and do not have aqua affinity
-    const aquaAffinityLevel = getEnchantmentLevel('aqua_affinity', enchantments)
-
-    if (inWater && aquaAffinityLevel === 0) {
-      blockBreakingSpeed /= 5.0
+    _getPropertiesPC () {
+      const properties = {}
+      const blockEnum = this.stateId === undefined ? registry.blocks[this.type] : registry.blocksByStateId[this.stateId]
+      if (blockEnum && blockEnum.states) {
+        let data = this.metadata
+        for (let i = blockEnum.states.length - 1; i >= 0; i--) {
+          const prop = blockEnum.states[i]
+          properties[prop.name] = propValue(prop, data % prop.num_values)
+          data = Math.floor(data / prop.num_values)
+        }
+      }
+      return properties
     }
 
-    // We always get 5x breaking speed de-buff if we are not on the ground
-    if (notOnGround) {
-      blockBreakingSpeed /= 5.0
+    _getPropertiesBedrock () {
+      const states = registry.blockStates[this.stateId].states
+      const ret = {}
+      for (const state in states) {
+        ret[state] = states[state].value
+      }
+      return ret
     }
 
-    // Compute block breaking delta (breaking progress applied in a single tick)
-    const blockHardness = this.hardness
-    const matchingToolMultiplier = this.canHarvest(heldItemType) ? 30.0 : 100.0
-
-    let blockBreakingDelta = blockBreakingSpeed / blockHardness / matchingToolMultiplier
-
-    // Delta will always be zero if block has -1.0 durability
-    if (blockHardness === -1.0) {
-      blockBreakingDelta = 0.0
+    getProperties () {
+      if (version.type === 'pc') {
+        return this._getPropertiesPC()
+      } else if (version.type === 'bedrock') {
+        return this._getPropertiesBedrock()
+      }
     }
 
-    // We will never be capable of breaking block if delta is zero, so abort now and return infinity
-    if (blockBreakingDelta === 0.0) {
-      return Infinity
+    canHarvest (heldItemType) {
+      if (!this.harvestTools) { return true }; // for blocks harvestable by hand
+      return heldItemType && this.harvestTools && this.harvestTools[heldItemType]
     }
 
-    // If breaking delta is more than 1.0 per tick, the block is broken instantly, so return 0
-    if (blockBreakingDelta >= 1.0) {
-      return 0
+    // http://minecraft.gamepedia.com/Breaking#Calculation
+    // for more concrete information, look up following Minecraft methods (assuming yarn mappings):
+    // AbstractBlock#calcBlockBreakingDelta, PlayerEntity#getBlockBreakingSpeed, PlayerEntity#canHarvest
+    digTime (heldItemType, creative, inWater, notOnGround, enchantments = [], effects = {}) {
+      if (creative) return 0
+
+      const materialToolMultipliers = registry.materials[this.material]
+      const isBestTool = heldItemType && materialToolMultipliers && materialToolMultipliers[heldItemType]
+
+      // Compute breaking speed multiplier
+      let blockBreakingSpeed = 1
+
+      if (isBestTool) {
+        blockBreakingSpeed = materialToolMultipliers[heldItemType]
+      }
+
+      // Efficiency is applied if tools speed multiplier is more than 1.0
+      const efficiencyLevel = getEnchantmentLevel('efficiency', enchantments)
+      if (efficiencyLevel > 0 && blockBreakingSpeed > 1.0) {
+        blockBreakingSpeed += efficiencyLevel * efficiencyLevel + 1
+      }
+
+      // Haste is always considered when effect is present, and when both
+      // Conduit Power and Haste are present, highest level is considered
+      const hasteLevel = Math.max(
+        getEffectLevel(statusEffectNames.hasteEffectName, effects),
+        getEffectLevel(statusEffectNames.conduitPowerEffectName, effects))
+
+      if (hasteLevel > 0) {
+        blockBreakingSpeed *= 1 + (0.2 * hasteLevel)
+      }
+
+      // Mining fatigue is applied afterwards, but multiplier only decreases up to level 4
+      const miningFatigueLevel = getEffectLevel(statusEffectNames.miningFatigueEffectName, effects)
+
+      if (miningFatigueLevel > 0) {
+        blockBreakingSpeed *= getMiningFatigueMultiplier(miningFatigueLevel)
+      }
+
+      // Apply 5x breaking speed de-buff if we are submerged in water and do not have aqua affinity
+      const aquaAffinityLevel = getEnchantmentLevel('aqua_affinity', enchantments)
+
+      if (inWater && aquaAffinityLevel === 0) {
+        blockBreakingSpeed /= 5.0
+      }
+
+      // We always get 5x breaking speed de-buff if we are not on the ground
+      if (notOnGround) {
+        blockBreakingSpeed /= 5.0
+      }
+
+      // Compute block breaking delta (breaking progress applied in a single tick)
+      const blockHardness = this.hardness
+      const matchingToolMultiplier = this.canHarvest(heldItemType) ? 30.0 : 100.0
+
+      let blockBreakingDelta = blockBreakingSpeed / blockHardness / matchingToolMultiplier
+
+      // Delta will always be zero if block has -1.0 durability
+      if (blockHardness === -1.0) {
+        blockBreakingDelta = 0.0
+      }
+
+      // We will never be capable of breaking block if delta is zero, so abort now and return infinity
+      if (blockBreakingDelta === 0.0) {
+        return Infinity
+      }
+
+      // If breaking delta is more than 1.0 per tick, the block is broken instantly, so return 0
+      if (blockBreakingDelta >= 1.0) {
+        return 0
+      }
+
+      // Determine how many ticks breaking will take, then convert to millis and return result
+      // We round ticks up because if progress is below 1.0, it will be finished next tick
+
+      const ticksToBreakBlock = Math.ceil(1.0 / blockBreakingDelta)
+      return ticksToBreakBlock * 50
     }
-
-    // Determine how many ticks breaking will take, then convert to millis and return result
-    // We round ticks up because if progress is below 1.0, it will be finished next tick
-
-    const ticksToBreakBlock = Math.ceil(1.0 / blockBreakingDelta)
-    return ticksToBreakBlock * 50
   }
 
-  return Block
+  function parseValue (value, state) {
+    if (state.type === 'enum') {
+      return state.values.indexOf(value)
+    }
+    if (state.type === 'bool') {
+      if (value === true) return 0
+      if (value === false) return 1
+    }
+    // Assume by-name mapping for unknown properties
+    return state.values?.indexOf(value.toString()) ?? 0
+  }
+
+  function getStateValue (states, name, value) {
+    let offset = 1
+    for (let i = states.length - 1; i >= 0; i--) {
+      const state = states[i]
+      if (state.name === name) {
+        return offset * parseValue(value, state)
+      }
+      offset *= state.num_values
+    }
+    return 0
+  }
+
+  function propValue (state, value) {
+    if (state.type === 'enum') return state.values[value]
+    if (state.type === 'bool') return !value
+    return value
+  }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "dependencies": {
     "prismarine-biome": "^1.1.0",
     "prismarine-item": "^1.10.1",
-    "prismarine-registry": "^1.1.0"
+    "prismarine-registry": "^1.1.0",
+    "prismarine-nbt": "^2.0.0"
   },
   "peerDependencies": {
     "minecraft-data": "^2.62.1"
@@ -26,9 +27,7 @@
     "minecraft-data": "^2.62.1",
     "mocha": "^9.1.3",
     "prismarine-block": "file:",
-    "prismarine-nbt": "^2.0.0",
-    "standard": "^16.0.4",
-    "vec3": "^0.1.4"
+    "standard": "^16.0.4"
   },
   "keywords": [
     "prismarine",

--- a/package.json
+++ b/package.json
@@ -25,9 +25,10 @@
     "expect": "^27.3.1",
     "minecraft-data": "^2.62.1",
     "mocha": "^9.1.3",
+    "prismarine-block": "file:",
+    "prismarine-nbt": "^2.0.0",
     "standard": "^16.0.4",
-    "vec3": "^0.1.4",
-    "prismarine-block": "file:."
+    "vec3": "^0.1.4"
   },
   "keywords": [
     "prismarine",

--- a/test/entity.test.js
+++ b/test/entity.test.js
@@ -1,0 +1,32 @@
+/* eslint-env mocha */
+const assert = require('assert')
+const nbt = require('prismarine-nbt')
+
+describe('handles block entities', () => {
+  for (const version of ['pc_1.15.2', 'bedrock_1.18']) {
+    it('creates a block entity on ' + version, () => {
+      const registry = require('prismarine-registry')(version)
+      const Block = require('prismarine-block')(registry)
+      const chest = Block.fromStateId(registry.blocksByName.chest.defaultState)
+      const tag = nbt.comp({
+        Items: nbt.list(nbt.comp([
+          {
+            Slot: nbt.int(13),
+            id: nbt.string('minecraft:gray_die'),
+            Count: nbt.int(1),
+            Enchantments: nbt.list(nbt.comp([{
+              lvl: nbt.int(3),
+              id: nbt.string('minecraft:unbreaking'),
+              display: nbt.comp({
+                Lore: nbt.list(nbt.string(['{"text":"Unbreaking III"}']))
+              })
+            }]))
+          }
+        ]))
+      })
+      const simplified = nbt.simplify(tag)
+      chest.entity = tag
+      assert.deepEqual(simplified, chest.blockEntity)
+    })
+  }
+})

--- a/test/entity.test.js
+++ b/test/entity.test.js
@@ -3,7 +3,7 @@ const assert = require('assert')
 const nbt = require('prismarine-nbt')
 
 describe('handles block entities', () => {
-  for (const version of ['pc_1.15.2', 'bedrock_1.18']) {
+  for (const version of ['pc_1.15.2', 'bedrock_1.18.0']) {
     it('creates a block entity on ' + version, () => {
       const registry = require('prismarine-registry')(version)
       const Block = require('prismarine-block')(registry)


### PR DESCRIPTION
after #45 and https://github.com/PrismarineJS/prismarine-chunk/pull/162

Adds a .blockEntity property that calls nbt.simplify, to keep some compatibility with mineflayer. Updates to .blockEntity cannot be saved back or sent to clients by a server.