### PR TITLE
Set metadata to 0 when not defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,6 +140,8 @@ function provider (registry, { Biome, version, features }) {
       this.stateId = stateId
       this.computedStates = {}
 
+      if (this.metadata == null) this.metadata = 0
+
       if (stateId === undefined && type !== undefined) {
         const b = registry.blocks[type]
         // Make sure the block is actually valid and metadata is within valid bounds


### PR DESCRIPTION
When metadata is not given in the Block constructor it should default to 0 instead of undefined. undefined can lead to math errors that can lead to other modules treating metadata as NaN messing up a lot of things. 
stateId is already handled when not defined so metadata should too.