### PR TITLE
Add boolean as a valid property type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -135,7 +135,7 @@ declare class Block {
     /**
      * Parse the block state and return its properties.
      */
-    getProperties() : { [key: string]: string | number }
+    getProperties() : { [key: string]: string | number | boolean };
 
     /**
      * Tells you how long it will take to dig the block, in milliseconds.


### PR DESCRIPTION
This fixes getting the powered state of blocks like comparators