### PR TITLE
Fixed calculation issue in digTime() when block hardness is > 0 and < 1

### DIFF
--- a/index.js
+++ b/index.js
@@ -327,7 +327,7 @@ function provider (registry, { Biome, version, features }) {
       }
 
       // Compute block breaking delta (breaking progress applied in a single tick)
-      const blockHardness = this.hardness
+      const blockHardness = (this.hardness > 0 && this.hardness < 1) ? 1 : this.hardness
       const matchingToolMultiplier = this.canHarvest(heldItemType) ? 30.0 : 100.0
 
       let blockBreakingDelta = blockBreakingSpeed / blockHardness / matchingToolMultiplier


### PR DESCRIPTION
This is an attempt to fix an issue where pathfinding using PrismarineJS/mineflayer-pathfinder sometimes makes the bot freeze when calculating a path that includes a block surrounded by leaf blocks, if it doesn't have a hoe in its inventory.
This issue was observed by me and also reported in PrismarineJS/mineflayer-pathfinder#222 and PrismarineJS/mineflayer-pathfinder#142.

I've identified that the issue stems from the calculation of blockBreakingDelta at [index.js:333](https://github.com/PrismarineJS/prismarine-block/blob/master/index.js#L333), when blockHardness is between 0 and 1, dividing by it leads to large numbers for blockBreakingDelta.

My change restricts the value of blockHardness at index.js:330. If the blockHardness is between 0 and 1 (exclusive), we set it as 1, which should result in a reasonable value for blockBreakingDelta, and thus correct the bot's behavior. 

It's also worth noting that the blockBreakingDelta calculation at line 333 would have issues with dividing by zero for blocks with hardness 0. But as far as I can tell,  those blocks are intangible, so probably not a problem.
