### PR TITLE
Allow two variations of syntax in fromString

### DIFF
--- a/index.js
+++ b/index.js
@@ -249,8 +249,11 @@ function provider (registry, { Biome, version }) {
       const name = str.split('[', 1)[0]
       const propertiesStr = str.slice(name.length + 1, -1).split(',')
       if (!str.includes('["')) {
+        // Example state: `minecraft:candle[lit=true]` -> candle, {lit: "true"}
         return Block.fromProperties(name, Object.fromEntries(propertiesStr.map(property => property.split('='))), biomeId)
       } else {
+        // Kept for backwards compatibility
+        // Example state: `minecraft:candle["lit":true]` -> candle, {lit: 1}
         return Block.fromProperties(name, Object.fromEntries(propertiesStr.map(property => {
           const [key, value] = property.split(':')
           return [key.slice(1, -1), value.startsWith('"') ? value.slice(1, -1) : { true: 1, false: 0 }[value] ?? parseInt(value)]

--- a/index.js
+++ b/index.js
@@ -248,9 +248,9 @@ function provider (registry, { Biome, version }) {
       if (str.startsWith('minecraft:')) str = str.substring(10)
       const name = str.split('[', 1)[0]
       const propertiesStr = str.slice(name.length + 1, -1).split(',')
-      if (version.type === 'pc') {
+      if (!str.includes('["')) {
         return Block.fromProperties(name, Object.fromEntries(propertiesStr.map(property => property.split('='))), biomeId)
-      } else if (version.type === 'bedrock') {
+      } else {
         return Block.fromProperties(name, Object.fromEntries(propertiesStr.map(property => {
           const [key, value] = property.split(':')
           return [key.slice(1, -1), value.startsWith('"') ? value.slice(1, -1) : { true: 1, false: 0 }[value] ?? parseInt(value)]

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -168,6 +168,7 @@ describe('fromString', () => {
   const versions = {
     1.18: 'minecraft:candle[lit=true]',
     'pe_1.18.0': 'minecraft:candle["lit":true]',
+    1.19: 'minecraft:candle["lit":true]',
     '1.20': 'minecraft:candle[lit=true]'
   }
   for (const [version, str] of Object.entries(versions)) {


### PR DESCRIPTION
Refer to https://github.com/PrismarineJS/prismarine-chunk/pull/230#issuecomment-1683026911 for reason.

For the short reasoning:
It now allows bedrock data to also be able to use the java edition format. (like `minecraft:candle[lit=true]`)