### PR TITLE
Fix false value handling in fromProperties for post flatenning versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -209,6 +209,8 @@ function provider (registry, { Biome, version }) {
     static fromProperties (typeId, properties, biomeId) {
       const block = typeof typeId === 'string' ? registry.blocksByName[typeId] : registry.blocks[typeId]
 
+      if (!block) throw new Error('No matching block id found for ' + typeId + ' with properties ' + JSON.stringify(properties)) // This should not happen
+
       if (version.type === 'pc') {
         if (block.states) {
           let data = 0
@@ -359,8 +361,8 @@ function provider (registry, { Biome, version }) {
       return state.values.indexOf(value)
     }
     if (state.type === 'bool') {
-      if (value === true) return 0
-      if (value === false) return 1
+      if (value === true || value === 'true') return 0
+      if (value === false || value === 'false') return 1
     }
     if (state.type === 'int') {
       return value

--- a/index.js
+++ b/index.js
@@ -357,7 +357,7 @@ function provider (registry, { Biome, version }) {
   }
 
   function parseValue (value, state) {
-    if (state.type === 'enum') {
+    if (state.type === 'enum' || state.values) {
       return state.values.indexOf(value)
     }
     if (state.type === 'bool') {
@@ -384,7 +384,7 @@ function provider (registry, { Biome, version }) {
   }
 
   function propValue (state, value) {
-    if (state.type === 'enum') return state.values[value]
+    if (state.type === 'enum' || state.values) return state.values[value]
     if (state.type === 'bool') return !value
     return value
   }

--- a/index.js
+++ b/index.js
@@ -358,7 +358,7 @@ function provider (registry, { Biome, version }) {
 
   function parseValue (value, state) {
     if (state.type === 'enum' || state.values) {
-      return state.values.indexOf(value)
+      return state.values.indexOf(String(value))
     }
     if (state.type === 'bool') {
       if (value === true || value === 'true') return 0

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -130,7 +130,6 @@ describe('Dig time', () => {
           it('using iron_shovel', () => {
             const tool = registry.itemsByName[toolName]
             const block = Block.fromStateId(registry.blocksByName[blockName].defaultState)
-            console.log('Block', block)
             const time = block.digTime(tool.id, false, false, false, [], {})
             expect(time).toBe(750)
           })
@@ -174,7 +173,6 @@ describe('fromString', () => {
   for (const [version, str] of Object.entries(versions)) {
     const Block = require('prismarine-block')(version)
     const block = Block.fromString(str, 0)
-    console.log(block)
     expect(block.getProperties().lit).toBeTruthy()
   }
 })

--- a/test/fromProperties.test.js
+++ b/test/fromProperties.test.js
@@ -55,10 +55,16 @@ describe('versions should return block state and properties', () => {
       // make sure that .fromProperties works
       {
         const blockData = registry.blocksByName.light_weighted_pressure_plate
-        const properties = { pc: { power: 2 }, bedrock: { redstone_signal: 2 } }[e]
+        const properties = { pc: { power: '2' }, bedrock: { redstone_signal: 2 } }[e]
         const block = Block.fromProperties(blockData.name, properties, 0)
         assert(block.stateId >= blockData.minStateId && block.stateId <= blockData.maxStateId)
-        expect(block.getProperties()).toMatchObject(properties)
+        const propertiesNormalized = block.getProperties();
+        if (e === 'pc') {
+          for (const key in propertiesNormalized) {
+            propertiesNormalized[key] = propertiesNormalized[key].toString();
+          }
+        }
+        expect(propertiesNormalized).toMatchObject(properties)
       }
 
       // Make sure type IDs work

--- a/test/fromProperties.test.js
+++ b/test/fromProperties.test.js
@@ -4,6 +4,7 @@ const assert = require('assert')
 const testedVersions = require('..').testedVersions
 
 describe('Block From Properties', () => {
+  // PC (Java)
   it('spruce half slab: waterlogged, upper (pc_1.16.4)', () => {
     const registry = require('prismarine-registry')('1.16.4')
     const Block = require('prismarine-block')(registry)
@@ -14,6 +15,18 @@ describe('Block From Properties', () => {
     expect(block.stateId).toBe(8310)
     expect(block.getProperties()).toMatchObject(properties)
   })
+  it('Boolean properties are string (1.18.2, ...)', () => {
+    const registry = require('prismarine-registry')('1.18.2')
+    const Block = require('prismarine-block')(registry)
+    const signId = registry.blocksByName.oak_sign.id
+    const sourceProperties = { waterlogged: 'false', rotation: '8' }
+
+    const block = Block.fromProperties(signId, sourceProperties, 0)
+    expect(block.stateId).toBe(3455)
+    expect(block.getProperties()).toMatchObject({ waterlogged: false, rotation: 8 })
+  })
+
+  // Bedrock
   it('spruce half slab: waterlogged, upper (bedrock_1.17.10)', () => {
     const registry = require('prismarine-registry')('bedrock_1.17.10')
     const Block = require('prismarine-block')(registry)

--- a/test/fromProperties.test.js
+++ b/test/fromProperties.test.js
@@ -58,10 +58,10 @@ describe('versions should return block state and properties', () => {
         const properties = { pc: { power: '2' }, bedrock: { redstone_signal: 2 } }[e]
         const block = Block.fromProperties(blockData.name, properties, 0)
         assert(block.stateId >= blockData.minStateId && block.stateId <= blockData.maxStateId)
-        const propertiesNormalized = block.getProperties();
+        const propertiesNormalized = block.getProperties()
         if (e === 'pc') {
           for (const key in propertiesNormalized) {
-            propertiesNormalized[key] = propertiesNormalized[key].toString();
+            propertiesNormalized[key] = propertiesNormalized[key].toString()
           }
         }
         expect(propertiesNormalized).toMatchObject(properties)


### PR DESCRIPTION
Also add meaningful error when the block is not found and remove console.log s from tests

This is needed so prismarine-provider-anvil can correctly parse blocks with `false` states (1.14+ I guess)

ALSO fix properties parsing for snow & repeater as .values were not used from state for int type!