### PR TITLE
Change boundingBox to a string literal union

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -81,7 +81,7 @@ export declare class Block {
      * - block - currently, partially solid blocks, such as half-slabs and ladders, are considered entirely solid.
      * - empty - such as flowers and lava.
      */
-    boundingBox: string;
+    boundingBox: 'block' | 'empty';
 
     /**
      * If the block texture has some transparency.


### PR DESCRIPTION
Better for IDE auto complete and stuff (commit message incorrectly describes it as changing it to an enum but its a string literal union)